### PR TITLE
matplotlib 1.5.1 does not use _cmapnames

### DIFF
--- a/utils/post_unfolding/plot/plotting_tool_GUI/BandUP_plot_GUI.pyw
+++ b/utils/post_unfolding/plot/plotting_tool_GUI/BandUP_plot_GUI.pyw
@@ -280,7 +280,11 @@ class BandupPlotToolWindow(QtGui.QMainWindow):
 
     def get_available_cmaps(self):
         colormap_names = []
-        for m in plt.cm._cmapnames:
+        try:
+            cmapnames = plt.cm._cmapnames
+        except AttributeError:
+            cmapnames = plt.cm.dated
+        for m in cmapnames:
             colormap_names.append(m)
             if(m + '_r' in dir(plt.cm)):
                 colormap_names.append(m + '_r')


### PR DESCRIPTION
For the newest matplotlib the following changes are also required....  Please consider them.